### PR TITLE
유저 장애 정보 기반 관광지 추천 API

### DIFF
--- a/BEF/src/main/java/com/example/BEF/Disbled/Domain/Disabled.java
+++ b/BEF/src/main/java/com/example/BEF/Disbled/Domain/Disabled.java
@@ -1,0 +1,104 @@
+package com.example.BEF.Disbled.Domain;
+
+import com.example.BEF.Location.Domain.Location;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "disabled")
+@Getter @Setter
+public class Disabled {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "disabled_number")
+    private Long disabledNumber;
+
+    @ManyToOne
+    @JoinColumn(name = "content_id", nullable = false)
+    private Location location;
+
+    @Column(name = "parking")
+    private String parking;
+
+    @Column(name = "route")
+    private String route;
+
+    @Column(name = "public_transport")
+    private String publicTransport;
+
+    @Column(name = "ticket_office")
+    private String ticketOffice;
+
+    @Column(name = "promotion")
+    private String promotion;
+
+    @Column(name = "wheelchair")
+    private String wheelchair;
+
+    @Column(name = "entrance")
+    private String entrance;
+
+    @Column(name = "elevator")
+    private String elevator;
+
+    @Column(name = "restroom")
+    private String restroom;
+
+    @Column(name = "auditorium")
+    private String auditorium;
+
+    @Column(name = "room")
+    private String room;
+
+    @Column(name = "handicap_etc")
+    private String handicapEtc;
+
+    @Column(name = "braile_block")
+    private String braileBlock;
+
+    @Column(name = "help_dog")
+    private String helpDog;
+
+    @Column(name = "guide_human")
+    private String guideHuman;
+
+    @Column(name = "audio_guide")
+    private String audioGuide;
+
+    @Column(name = "big_print")
+    private String bigPrint;
+
+    @Column(name = "braile_promotion")
+    private String brailePromotion;
+
+    @Column(name = "guide_system")
+    private String guideSystem;
+
+    @Column(name = "blind_handicap_etc")
+    private String blindHandicapEtc;
+
+    @Column(name = "sign_guide")
+    private String signGuide;
+
+    @Column(name = "video_guide")
+    private String videoGuide;
+
+    @Column(name = "hearing_room")
+    private String hearingRoom;
+
+    @Column(name = "hearing_handicap_etc")
+    private String hearingHandicapEtc;
+
+    @Column(name = "stroller")
+    private String stroller;
+
+    @Column(name = "lactation_room")
+    private String lactationRoom;
+
+    @Column(name = "baby_spare_chair")
+    private String babySpareChair;
+
+    @Column(name = "infants_family_etc")
+    private String infantsFamilyEtc;
+}

--- a/BEF/src/main/java/com/example/BEF/Disbled/Service/DisabledRepository.java
+++ b/BEF/src/main/java/com/example/BEF/Disbled/Service/DisabledRepository.java
@@ -2,6 +2,29 @@ package com.example.BEF.Disbled.Service;
 
 import com.example.BEF.Disbled.Domain.Disabled;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface DisabledRepository extends JpaRepository<Disabled, Long> {
+
+    // 노약자 필터링 (엘리베이터 또는 경로가 null이 아니고 빈 문자열이 아님)
+    @Query("SELECT d FROM Disabled d WHERE d.elevator IS NOT NULL AND d.elevator <> '' OR d.route IS NOT NULL AND d.route <> ''")
+    List<Disabled> findByValidElevatorOrRoute();
+
+    // 휠체어 필터링 (엘리베이터, 출입구, 대중교통이 null이 아니고 빈 문자열이 아님)
+    @Query("SELECT d FROM Disabled d WHERE d.elevator IS NOT NULL AND d.elevator <> '' AND d.entrance IS NOT NULL AND d.entrance <> '' AND d.publicTransport IS NOT NULL AND d.publicTransport <> ''")
+    List<Disabled> findByValidElevatorAndEntranceAndPublicTransport();
+
+    // 시각 장애 필터링 (점자 블록과 안내 요원이 null이 아니고 빈 문자열이 아님)
+    @Query("SELECT d FROM Disabled d WHERE d.braileBlock IS NOT NULL AND d.braileBlock <> '' AND d.guideHuman IS NOT NULL AND d.guideHuman <> ''")
+    List<Disabled> findByValidBraileBlockAndGuideHuman();
+
+    // 청각 장애 필터링 (수어 가이드, 비디오 가이드, 청각 장애 전용 객실 중 하나가 null이 아니고 빈 문자열이 아님)
+    @Query("SELECT d FROM Disabled d WHERE d.signGuide IS NOT NULL AND d.signGuide <> '' OR d.videoGuide IS NOT NULL AND d.videoGuide <> '' OR d.hearingRoom IS NOT NULL AND d.hearingRoom <> '' OR d.hearingHandicapEtc IS NOT NULL AND d.hearingHandicapEtc <> ''")
+    List<Disabled> findByValidSignGuideOrVideoGuideOrHearingRoomOrHearingHandicapEtc();
+
+    // 영유아 관련 필터링 (유모차, 수유실, 아기 의자가 중 하나가 null이 아니고 빈 문자열이 아님)
+    @Query("SELECT d FROM Disabled d WHERE d.stroller IS NOT NULL AND d.stroller <> '' OR d.lactationRoom IS NOT NULL AND d.lactationRoom <> '' OR d.babySpareChair IS NOT NULL AND d.babySpareChair <> '' OR d.infantsFamilyEtc IS NOT NULL AND d.infantsFamilyEtc <> ''")
+    List<Disabled> findByValidStrollerOrLactationRoomOrBabySpareChairOrInfantsFamilyEtc();
 }

--- a/BEF/src/main/java/com/example/BEF/Disbled/Service/DisabledRepository.java
+++ b/BEF/src/main/java/com/example/BEF/Disbled/Service/DisabledRepository.java
@@ -1,0 +1,7 @@
+package com.example.BEF.Disbled.Service;
+
+import com.example.BEF.Disbled.Domain.Disabled;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DisabledRepository extends JpaRepository<Disabled, Long> {
+}

--- a/BEF/src/main/java/com/example/BEF/Disbled/Service/DisabledService.java
+++ b/BEF/src/main/java/com/example/BEF/Disbled/Service/DisabledService.java
@@ -1,0 +1,132 @@
+package com.example.BEF.Disbled.Service;
+
+import com.example.BEF.Disbled.Domain.Disabled;
+import com.example.BEF.User.DTO.UserDisabledDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+public class DisabledService {
+    // 관광지 장애 정보 필터링
+    public List<Disabled> filteringDisabled(UserDisabledDTO userDiabledDTO, List<Disabled> disabledList) {
+        List<Disabled> filteredList = new ArrayList<>();
+
+        for (Disabled location : disabledList) {
+            if (userDiabledDTO.getSenior() && seniorAvail(location))
+            {
+                log.info("노약자 관광지 : {}", location);
+                filteredList.add(location);
+            }
+            else if (userDiabledDTO.getWheelchair() && wheelchiarAvail(location))
+            {
+                log.info("휠체어 관광지 : {}", location);
+                filteredList.add(location);
+            }
+            else if (userDiabledDTO.getBlind_handicap() && blindAvail(location))
+            {
+                log.info("시각 장애 관광지 : {}", location);
+                filteredList.add(location);
+            }
+            else if (userDiabledDTO.getHearing_handicap() && hearingAvail(location))
+            {
+                log.info("청각 장애 관광지 : {}", location);
+                filteredList.add(location);
+            }
+            else if (userDiabledDTO.getInfants_family() && infantsAvail(location))
+            {
+                log.info("영유아 관광지 : {}", location);
+                filteredList.add(location);
+            }
+        }
+
+        return (filteredList);
+    }
+
+    // 관광지 - 노약자 관련 필터링
+    public Boolean seniorAvail(Disabled location) {
+//        if (location.getParking() != null)
+//            return (true);
+        if (!location.getRoute().isBlank())
+            return (true);
+//        else if (location.getPublicTransport() != null)
+//            return (true);
+//        else if (location.getEntrance() != null)
+//            return (true);
+        else
+            return (!location.getElevator().isBlank());
+//        else
+//            return location.getPromotion() != null;
+    }
+
+    // 관광지 - 휠체어 관련 필터링
+    public Boolean wheelchiarAvail(Disabled location) {
+//        if (location.getParking() != null)
+//            return (true);
+//        else if (location.getRoute() != null)
+//            return (true);
+        if (!location.getPublicTransport().isBlank())
+            return (true);
+        else if (!location.getWheelchair().isBlank())
+            return (true);
+        else if (!location.getEntrance().isBlank())
+            return (true);
+        else if (!location.getElevator().isBlank())
+            return (true);
+//        else if (location.getRestroom() != null)
+//            return (true);
+        else if (!location.getAuditorium().isBlank())
+            return (true);
+        else if (!location.getRoom().isBlank())
+            return (true);
+        else
+            return (!location.getHandicapEtc().isBlank());
+    }
+
+    // 관광지 - 시각 장애 관련 필터링
+    public Boolean blindAvail(Disabled location) {
+        if (!location.getBraileBlock().isBlank())
+            return (true);
+        else if (!location.getHelpDog().isBlank())
+            return (true);
+        else if (!location.getGuideHuman().isBlank())
+            return (true);
+        else if (!location.getAudioGuide().isBlank())
+            return (true);
+        else if (!location.getBigPrint().isBlank())
+            return (true);
+        else if (!location.getBrailePromotion().isBlank())
+            return (true);
+        else if (!location.getGuideSystem().isBlank())
+            return (true);
+        else
+            return (!location.getBlindHandicapEtc().isBlank());
+    }
+
+    // 관광지 - 청각 장애 관련 필터링
+    public Boolean hearingAvail(Disabled location) {
+        if (!location.getSignGuide().isBlank())
+            return (true);
+        else if (!location.getVideoGuide().isBlank())
+            return (true);
+        else if (!location.getHearingRoom().isBlank())
+            return (true);
+        else
+            return (!location.getHearingHandicapEtc().isBlank());
+    }
+
+    // 관광지 - 영유아 관련 필터링
+    public Boolean infantsAvail(Disabled location) {
+        if (!location.getStroller().isBlank())
+            return (true);
+        else if (!location.getLactationRoom().isBlank())
+            return (true);
+        else if (!location.getBabySpareChair().isBlank())
+            return (true);
+        else
+            return (!location.getInfantsFamilyEtc().isBlank());
+    }
+}

--- a/BEF/src/main/java/com/example/BEF/Disbled/Service/DisabledService.java
+++ b/BEF/src/main/java/com/example/BEF/Disbled/Service/DisabledService.java
@@ -3,130 +3,48 @@ package com.example.BEF.Disbled.Service;
 import com.example.BEF.Disbled.Domain.Disabled;
 import com.example.BEF.User.DTO.UserDisabledDTO;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 @Service
 @Slf4j
 public class DisabledService {
-    // 관광지 장애 정보 필터링
-    public List<Disabled> filteringDisabled(UserDisabledDTO userDiabledDTO, List<Disabled> disabledList) {
-        List<Disabled> filteredList = new ArrayList<>();
 
-        for (Disabled location : disabledList) {
-            if (userDiabledDTO.getSenior() && seniorAvail(location))
-            {
-                log.info("노약자 관광지 : {}", location);
-                filteredList.add(location);
-            }
-            else if (userDiabledDTO.getWheelchair() && wheelchiarAvail(location))
-            {
-                log.info("휠체어 관광지 : {}", location);
-                filteredList.add(location);
-            }
-            else if (userDiabledDTO.getBlind_handicap() && blindAvail(location))
-            {
-                log.info("시각 장애 관광지 : {}", location);
-                filteredList.add(location);
-            }
-            else if (userDiabledDTO.getHearing_handicap() && hearingAvail(location))
-            {
-                log.info("청각 장애 관광지 : {}", location);
-                filteredList.add(location);
-            }
-            else if (userDiabledDTO.getInfants_family() && infantsAvail(location))
-            {
-                log.info("영유아 관광지 : {}", location);
-                filteredList.add(location);
-            }
-        }
+    @Autowired
+    DisabledRepository disabledRepository;
+
+    // 관광지 장애 정보 필터링
+    public Set<Disabled> filteringDisabled(UserDisabledDTO userDiabledDTO) {
+        Set<Disabled> filteredList = new HashSet<>();
+
+        // 노약자 필터링
+        // 필터링 : 엘리베이터 || 대중교통
+        if (userDiabledDTO.getSenior())
+            filteredList.addAll(disabledRepository.findByValidElevatorOrRoute());
+
+        // 휠체어 필터링
+        // 필터링 : 엘리베이터 && 출입통로 && 경사로
+        if (userDiabledDTO.getWheelchair())
+            filteredList.addAll(disabledRepository.findByValidElevatorAndEntranceAndPublicTransport());
+
+        // 시각 장애 필터링
+        // 필터링 : 점자블록 && 안내요원
+        if (userDiabledDTO.getBlind_handicap())
+            filteredList.addAll(disabledRepository.findByValidBraileBlockAndGuideHuman());
+
+        // 청각 장애 필터링
+        // 필터링 : 수화 || 비디오 가이드 || 객실 || 청각 장애 기타 상세
+        if (userDiabledDTO.getHearing_handicap())
+            filteredList.addAll(disabledRepository.findByValidSignGuideOrVideoGuideOrHearingRoomOrHearingHandicapEtc());
+
+        // 영유아 필터링
+        // 필터링 : 유모차 || 수유실 || 보조 의자 || 영유아 기타 상세
+        if (userDiabledDTO.getInfants_family())
+            filteredList.addAll(disabledRepository.findByValidStrollerOrLactationRoomOrBabySpareChairOrInfantsFamilyEtc());
 
         return (filteredList);
-    }
-
-    // 관광지 - 노약자 관련 필터링
-    public Boolean seniorAvail(Disabled location) {
-//        if (location.getParking() != null)
-//            return (true);
-        if (!location.getRoute().isBlank())
-            return (true);
-//        else if (location.getPublicTransport() != null)
-//            return (true);
-//        else if (location.getEntrance() != null)
-//            return (true);
-        else
-            return (!location.getElevator().isBlank());
-//        else
-//            return location.getPromotion() != null;
-    }
-
-    // 관광지 - 휠체어 관련 필터링
-    public Boolean wheelchiarAvail(Disabled location) {
-//        if (location.getParking() != null)
-//            return (true);
-//        else if (location.getRoute() != null)
-//            return (true);
-        if (!location.getPublicTransport().isBlank())
-            return (true);
-        else if (!location.getWheelchair().isBlank())
-            return (true);
-        else if (!location.getEntrance().isBlank())
-            return (true);
-        else if (!location.getElevator().isBlank())
-            return (true);
-//        else if (location.getRestroom() != null)
-//            return (true);
-        else if (!location.getAuditorium().isBlank())
-            return (true);
-        else if (!location.getRoom().isBlank())
-            return (true);
-        else
-            return (!location.getHandicapEtc().isBlank());
-    }
-
-    // 관광지 - 시각 장애 관련 필터링
-    public Boolean blindAvail(Disabled location) {
-        if (!location.getBraileBlock().isBlank())
-            return (true);
-        else if (!location.getHelpDog().isBlank())
-            return (true);
-        else if (!location.getGuideHuman().isBlank())
-            return (true);
-        else if (!location.getAudioGuide().isBlank())
-            return (true);
-        else if (!location.getBigPrint().isBlank())
-            return (true);
-        else if (!location.getBrailePromotion().isBlank())
-            return (true);
-        else if (!location.getGuideSystem().isBlank())
-            return (true);
-        else
-            return (!location.getBlindHandicapEtc().isBlank());
-    }
-
-    // 관광지 - 청각 장애 관련 필터링
-    public Boolean hearingAvail(Disabled location) {
-        if (!location.getSignGuide().isBlank())
-            return (true);
-        else if (!location.getVideoGuide().isBlank())
-            return (true);
-        else if (!location.getHearingRoom().isBlank())
-            return (true);
-        else
-            return (!location.getHearingHandicapEtc().isBlank());
-    }
-
-    // 관광지 - 영유아 관련 필터링
-    public Boolean infantsAvail(Disabled location) {
-        if (!location.getStroller().isBlank())
-            return (true);
-        else if (!location.getLactationRoom().isBlank())
-            return (true);
-        else if (!location.getBabySpareChair().isBlank())
-            return (true);
-        else
-            return (!location.getInfantsFamilyEtc().isBlank());
     }
 }

--- a/BEF/src/main/java/com/example/BEF/Location/Controller/LocationController.java
+++ b/BEF/src/main/java/com/example/BEF/Location/Controller/LocationController.java
@@ -1,0 +1,35 @@
+package com.example.BEF.Location.Controller;
+
+import com.example.BEF.Location.DTO.UserLocationRes;
+import com.example.BEF.Location.Service.LocationService;
+import com.example.BEF.User.Service.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/location")
+public class LocationController {
+    @Autowired
+    LocationService locationService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    // 유저 장애 정보 기반 관광지 리스트 검색
+    @GetMapping("/recommend")
+    public ResponseEntity<List<UserLocationRes>> getUserLocations(@RequestParam("userNumber") Long userNumber) {
+        // 존재하지 않는 유저인 경우
+        if (userRepository.findUserByUserNumber(userNumber) == null)
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+
+        // 필터링된 관광지 리스트 리턴
+        return new ResponseEntity<>(locationService.findLocationWithDisabled(userNumber), HttpStatus.OK);
+    }
+}

--- a/BEF/src/main/java/com/example/BEF/Location/DTO/UserLocationRes.java
+++ b/BEF/src/main/java/com/example/BEF/Location/DTO/UserLocationRes.java
@@ -1,0 +1,16 @@
+package com.example.BEF.Location.DTO;
+
+import lombok.Data;
+
+@Data
+public class UserLocationRes {
+    private String content_title;
+    private String addr;
+    private String thumbnail_image;
+
+    public UserLocationRes(String content_title, String addr, String thumbnail_image) {
+        this.content_title = content_title;
+        this.addr = addr;
+        this.thumbnail_image = thumbnail_image;
+    }
+}

--- a/BEF/src/main/java/com/example/BEF/Location/Service/LocationService.java
+++ b/BEF/src/main/java/com/example/BEF/Location/Service/LocationService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Service
 @Slf4j
@@ -30,10 +31,9 @@ public class LocationService {
     public List<UserLocationRes> findLocationWithDisabled(Long userNumber) {
         // 유저 장애 정보
         UserDisabledDTO userDiabledDTO = userService.settingUserDisabled(userNumber);
-        log.info(userDiabledDTO.toString());
 
         // 필터링 된 관광지 장애 정보 리스트
-        List<Disabled> disabledList = disabledService.filteringDisabled(userDiabledDTO, disabledRepository.findAll());
+        Set<Disabled> disabledList = disabledService.filteringDisabled(userDiabledDTO);
         List<UserLocationRes> userLocationResList = new ArrayList<>();
 
         // 필터링 된 관광지 정보 리스트 리턴

--- a/BEF/src/main/java/com/example/BEF/Location/Service/LocationService.java
+++ b/BEF/src/main/java/com/example/BEF/Location/Service/LocationService.java
@@ -1,0 +1,49 @@
+package com.example.BEF.Location.Service;
+
+import com.example.BEF.Disbled.Domain.Disabled;
+import com.example.BEF.Disbled.Service.DisabledRepository;
+import com.example.BEF.Disbled.Service.DisabledService;
+import com.example.BEF.Location.DTO.UserLocationRes;
+import com.example.BEF.Location.Domain.Location;
+import com.example.BEF.User.DTO.UserDisabledDTO;
+import com.example.BEF.User.Service.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+public class LocationService {
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    DisabledService disabledService;
+
+    @Autowired
+    DisabledRepository disabledRepository;
+
+    // 관광지 필터링 - 유저 장애 정보 관련
+    public List<UserLocationRes> findLocationWithDisabled(Long userNumber) {
+        // 유저 장애 정보
+        UserDisabledDTO userDiabledDTO = userService.settingUserDisabled(userNumber);
+        log.info(userDiabledDTO.toString());
+
+        // 필터링 된 관광지 장애 정보 리스트
+        List<Disabled> disabledList = disabledService.filteringDisabled(userDiabledDTO, disabledRepository.findAll());
+        List<UserLocationRes> userLocationResList = new ArrayList<>();
+
+        // 필터링 된 관광지 정보 리스트 리턴
+        for (Disabled disabled : disabledList) {
+            Location location = disabled.getLocation();
+            UserLocationRes userLocationRes = new UserLocationRes(location.getContentTitle(), location.getAddr(), location.getThumbnailImage());
+            userLocationResList.add(userLocationRes);
+        }
+
+        log.info("관광지 리스트 개수 : {}", userLocationResList.size());
+        return (userLocationResList);
+    }
+}

--- a/BEF/src/main/java/com/example/BEF/User/Controller/UserController.java
+++ b/BEF/src/main/java/com/example/BEF/User/Controller/UserController.java
@@ -1,0 +1,34 @@
+package com.example.BEF.User.Controller;
+
+import com.example.BEF.User.DTO.UserJoinReq;
+import com.example.BEF.User.DTO.UserJoinRes;
+import com.example.BEF.User.Service.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequestMapping("/user")
+public class UserController {
+    @Autowired
+    UserService userService;
+
+    @PostMapping("/join")
+    public ResponseEntity<UserJoinRes> join(@RequestBody UserJoinReq userJoinReq) {
+
+        UserJoinRes savedUserJoinRes = userService.saveUser(userJoinReq);
+
+        // 회원가입 실패시
+        if (savedUserJoinRes == null)
+            return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        // 회원가입 성공시
+        else
+            return new ResponseEntity<>(savedUserJoinRes, HttpStatus.CREATED);
+    }
+}

--- a/BEF/src/main/java/com/example/BEF/User/DTO/UserDisabledDTO.java
+++ b/BEF/src/main/java/com/example/BEF/User/DTO/UserDisabledDTO.java
@@ -1,0 +1,20 @@
+package com.example.BEF.User.DTO;
+
+import lombok.Data;
+
+@Data
+public class UserDisabledDTO {
+    private Boolean senior;
+    private Boolean wheelchair;
+    private Boolean blind_handicap;
+    private Boolean hearing_handicap;
+    private Boolean infants_family;
+
+    public UserDisabledDTO(Boolean senior, Boolean wheelchair, Boolean blind_handicap, Boolean hearing_handicap, Boolean infants_family) {
+        this.senior = senior;
+        this.wheelchair = wheelchair;
+        this.blind_handicap = blind_handicap;
+        this.hearing_handicap = hearing_handicap;
+        this.infants_family = infants_family;
+    }
+}

--- a/BEF/src/main/java/com/example/BEF/User/DTO/UserJoinReq.java
+++ b/BEF/src/main/java/com/example/BEF/User/DTO/UserJoinReq.java
@@ -1,0 +1,35 @@
+package com.example.BEF.User.DTO;
+
+import lombok.Data;
+
+@Data
+public class UserJoinReq {
+    private String userName;
+    private String gender;
+    private Long age;
+    private Boolean senior;
+    private Boolean wheelchair;
+    private Boolean blindHandicap;
+    private Boolean hearingHandicap;
+    private Boolean infantsFamily;
+
+    public boolean validJoin() {
+        if (userName == null || userName.isBlank())
+            return false;
+        else if (gender == null || gender.isBlank())
+            return false;
+        else if (age == null || age.equals(0L))
+            return false;
+        else if (senior == null)
+            return false;
+        else if (wheelchair == null)
+            return false;
+        else if (blindHandicap == null)
+            return false;
+        else if (hearingHandicap == null)
+            return false;
+        else if (infantsFamily == null)
+            return false;
+        return true;
+    }
+}

--- a/BEF/src/main/java/com/example/BEF/User/DTO/UserJoinRes.java
+++ b/BEF/src/main/java/com/example/BEF/User/DTO/UserJoinRes.java
@@ -1,0 +1,14 @@
+package com.example.BEF.User.DTO;
+
+import lombok.Data;
+
+@Data
+public class UserJoinRes {
+    private Long userNumber;
+    private String userName;
+
+    public UserJoinRes(Long userNumber, String userName) {
+        this.userNumber = userNumber;
+        this.userName = userName;
+    }
+}

--- a/BEF/src/main/java/com/example/BEF/User/Domain/User.java
+++ b/BEF/src/main/java/com/example/BEF/User/Domain/User.java
@@ -1,0 +1,52 @@
+package com.example.BEF.User.Domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "user")
+@Getter @Setter
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userNumber;      // 유저 번호
+
+    @Column(name = "user_name")
+    private String userName;      // 유저 이름
+
+    @Column(name = "gender")
+    private String gender;        // 성별
+
+    @Column(name = "age")
+    private Long age;             // 나이
+
+    @Column(name = "senior")
+    private Boolean senior;       // 노약자
+
+    @Column(name = "wheelchair")
+    private Boolean wheelchair;   // 휠체어
+
+    @Column(name = "blind_handicap")
+    private Boolean blindHandicap; // 시각 장애
+
+    @Column(name = "hearing_handicap")
+    private Boolean hearingHandicap; // 청각 장애
+
+    @Column(name = "infants_family")
+    private Boolean infantsFamily; // 영유아 가족
+
+    public User(String userName, String gender, Long age, Boolean senior, Boolean wheelchair, Boolean blindHandicap, Boolean hearingHandicap, Boolean infantsFamily) {
+        this.userName = userName;
+        this.gender = gender;
+        this.age = age;
+        this.senior = senior;
+        this.wheelchair = wheelchair;
+        this.blindHandicap = blindHandicap;
+        this.hearingHandicap = hearingHandicap;
+        this.infantsFamily = infantsFamily;
+    }
+}

--- a/BEF/src/main/java/com/example/BEF/User/Service/UserRepository.java
+++ b/BEF/src/main/java/com/example/BEF/User/Service/UserRepository.java
@@ -4,4 +4,5 @@ import com.example.BEF.User.Domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    User findUserByUserNumber(Long userNumber);
 }

--- a/BEF/src/main/java/com/example/BEF/User/Service/UserRepository.java
+++ b/BEF/src/main/java/com/example/BEF/User/Service/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.BEF.User.Service;
+
+import com.example.BEF.User.Domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/BEF/src/main/java/com/example/BEF/User/Service/UserService.java
+++ b/BEF/src/main/java/com/example/BEF/User/Service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.BEF.User.Service;
 
+import com.example.BEF.User.DTO.UserDisabledDTO;
 import com.example.BEF.User.DTO.UserJoinReq;
 import com.example.BEF.User.DTO.UserJoinRes;
 import com.example.BEF.User.Domain.User;
@@ -34,5 +35,12 @@ public class UserService {
 
         // 유저 정보 리턴
         return (new UserJoinRes(savedUser.getUserNumber(), savedUser.getUserName()));
+    }
+
+    public UserDisabledDTO settingUserDisabled(Long userNumber) {
+        User disabledUser = userRepository.findUserByUserNumber(userNumber);
+
+        return (new UserDisabledDTO(disabledUser.getSenior(), disabledUser.getWheelchair(),
+                disabledUser.getBlindHandicap(), disabledUser.getHearingHandicap(), disabledUser.getInfantsFamily()));
     }
 }

--- a/BEF/src/main/java/com/example/BEF/User/Service/UserService.java
+++ b/BEF/src/main/java/com/example/BEF/User/Service/UserService.java
@@ -1,0 +1,38 @@
+package com.example.BEF.User.Service;
+
+import com.example.BEF.User.DTO.UserJoinReq;
+import com.example.BEF.User.DTO.UserJoinRes;
+import com.example.BEF.User.Domain.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+    @Autowired
+    UserRepository userRepository;
+
+    public UserJoinRes saveUser(UserJoinReq userJoinReq) {
+        // 저장할 유저 생성
+        User savedUser = new User();
+
+        // 회원가입 가능 여부 확인
+        if (!userJoinReq.validJoin())
+            return (null);
+
+        // 유저 정보 기입
+        savedUser.setUserName(userJoinReq.getUserName());
+        savedUser.setGender(userJoinReq.getGender());
+        savedUser.setAge(userJoinReq.getAge());
+        savedUser.setSenior(userJoinReq.getSenior());
+        savedUser.setWheelchair(userJoinReq.getWheelchair());
+        savedUser.setBlindHandicap(userJoinReq.getBlindHandicap());
+        savedUser.setHearingHandicap(userJoinReq.getHearingHandicap());
+        savedUser.setInfantsFamily(userJoinReq.getInfantsFamily());
+
+        // 유저 저장
+        userRepository.save(savedUser);
+
+        // 유저 정보 리턴
+        return (new UserJoinRes(savedUser.getUserNumber(), savedUser.getUserName()));
+    }
+}


### PR DESCRIPTION
## 유저 장애 정보 기반 관광지 추천 API
### 현재 필터링 기준 - 개선 필요

아래 필터링 기준 중 하나라도 해당 되는 경우 추천 관광지에 추가하는 방식

**휠체어**
경사로, 휠체어 대여, 출입통로, 엘리베이터, 휠체어 관람석, 객실, 지체 장애 기타 상세

**노약자**
엘리베이터, 대중교통

**시각 장애**
점자블록, 보조견 동반, 안내요원, 유도 설비, 오디오 가이드, 큰활자홍보물, 점자 홍보물, 시각 장애 기타 상세

**청각 장애**
수화, 자막 안내, 객실, 청각 장애 기타 상세

**영유아**
유모차 대여, 수유실, 유아 보조 의자, 영유아 기타 상세

### 로직
1. 유저 번호를 통해 해당 유저의 장애 정보 구하기
2. 유저 장애 정보 기반으로 관광지 장애 정보에서 해당 유저의 장애 정보와 연관 있는 관광지 필터링
3. 필터링 된 관광지에서 관광지명, 주소, 썸네일 이미지 뽑아와 관광지 리스트 리턴