### PR TITLE
검색기능, 지도기반 장소 제공 기능의 응답값  ContentID 추가 

### DIFF
--- a/BEF/src/main/java/com/example/BEF/MapLocation/DTO/MapLocationResponse.java
+++ b/BEF/src/main/java/com/example/BEF/MapLocation/DTO/MapLocationResponse.java
@@ -6,6 +6,7 @@ import com.example.BEF.Location.Domain.Location;
 public class MapLocationResponse {
 
     //location 관련 컬럼
+    private Long contentId;
     private String contentTitle;
     private String addr;
     private Double gpsX;
@@ -37,6 +38,7 @@ public class MapLocationResponse {
 
 
     public MapLocationResponse(Location location, Disabled disabled) {
+        this.contentId = location.getContentId();
         this.contentTitle = location.getContentTitle();
         this.addr = location.getAddr();
         this.gpsX = location.getGpsX();
@@ -61,6 +63,9 @@ public class MapLocationResponse {
             this.babySpareChair = disabled.getBabySpareChair();
         }
     }
+    public Long getContentId() { return contentId; }
+
+    public void setContentId(Long contentId) { this.contentId = contentId; }
 
     public String getContentTitle() {
         return contentTitle;

--- a/BEF/src/main/java/com/example/BEF/Search/SearchController.java
+++ b/BEF/src/main/java/com/example/BEF/Search/SearchController.java
@@ -1,0 +1,24 @@
+package com.example.BEF.Search;
+
+import com.example.BEF.MapLocation.DTO.MapLocationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @GetMapping("/search")
+    public List<MapLocationResponse> searchLocations(@RequestParam("keyword") String keyword) {
+        // 키워드를 기반으로 Location과 Disabled 정보를 조합한 응답 리스트를 반환
+        return searchService.findByKeyword(keyword);
+    }
+}

--- a/BEF/src/main/java/com/example/BEF/Search/SearchRepository.java
+++ b/BEF/src/main/java/com/example/BEF/Search/SearchRepository.java
@@ -1,0 +1,13 @@
+package com.example.BEF.Search;
+
+import com.example.BEF.Location.Domain.Location;
+import feign.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface SearchRepository extends JpaRepository<Location , String> {
+    @Query("Select l From Location l where l.contentTitle Like %:keyword%")
+    List<Location> findByKeyword(@Param("keyword") String keyword);
+}

--- a/BEF/src/main/java/com/example/BEF/Search/SearchService.java
+++ b/BEF/src/main/java/com/example/BEF/Search/SearchService.java
@@ -1,0 +1,30 @@
+package com.example.BEF.Search;
+
+import com.example.BEF.Disabled.Domain.Disabled;
+import com.example.BEF.Disabled.Service.DisabledRepository;
+import com.example.BEF.Location.Domain.Location;
+import com.example.BEF.MapLocation.DTO.MapLocationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+    private final SearchRepository searchRepository;
+    private final DisabledRepository disabledRepository;
+
+    public List<MapLocationResponse> findByKeyword(String keyword) {
+        List<Location> locations = searchRepository.findByKeyword(keyword);
+
+        return locations.stream()
+                .map(location -> {
+                    Disabled disabled = disabledRepository.findDisabledByLocation(location);
+
+                    return new MapLocationResponse(location, disabled);
+                })
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 검색기능
검색 키워드를 통해 검색 키워드가 있는 관광지 이름 조회하여 제공
### 요청
- String keyword
### 응답
- 관광지ID, 관광지 이름, 관광지 주소, gpsX, gpsY, 원본이미지, 썸네일이미지, 장애지원 여부 리스트

###SeachController,SearchService
- 기존에 사용한 MapLocation Response를 이용하여 지도 기반 장소제공 기능 응답값과 동일한 응답값을 리턴한다.

## 지도기반 장소 제공기능
- 응답값의 관광지 ID 또한 추가적을 리턴가능하게 수정

