### PR TITLE
온보딩 및 유저별 여행 타입 + 장애 정보 필터링

### DIFF
--- a/BEF/build.gradle
+++ b/BEF/build.gradle
@@ -28,22 +28,24 @@ ext {
 }
 
 dependencies {
-	// lombok
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// Spring Boot 기본 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+	// JSON
 	implementation 'org.json:json:20210307'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 
-	// test
+	// Test 의존성
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	//Mysql
+	// MySQL 데이터베이스
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'mysql:mysql-connector-java:8.0.32'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/BEF/src/main/java/com/example/BEF/Disabled/Service/DisabledRepository.java
+++ b/BEF/src/main/java/com/example/BEF/Disabled/Service/DisabledRepository.java
@@ -5,29 +5,76 @@ import com.example.BEF.Disabled.Domain.Disabled;
 import com.example.BEF.Location.Domain.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Set;
 
 public interface DisabledRepository extends JpaRepository<Disabled, Long> {
     Disabled findDisabledByLocation(Location location);
 
-    // 노약자 필터링 (엘리베이터 또는 경로가 null이 아니고 빈 문자열이 아님)
-    @Query("SELECT d FROM Disabled d WHERE d.elevator IS NOT NULL AND d.elevator <> '' OR d.route IS NOT NULL AND d.route <> ''")
-    List<Disabled> findByValidElevatorOrRoute();
-
-    // 휠체어 필터링 (엘리베이터, 출입구, 대중교통이 null이 아니고 빈 문자열이 아님)
-    @Query("SELECT d FROM Disabled d WHERE d.elevator IS NOT NULL AND d.elevator <> '' AND d.entrance IS NOT NULL AND d.entrance <> '' AND d.publicTransport IS NOT NULL AND d.publicTransport <> ''")
-    List<Disabled> findByValidElevatorAndEntranceAndPublicTransport();
-
-    // 시각 장애 필터링 (점자 블록과 안내 요원이 null이 아니고 빈 문자열이 아님)
-    @Query("SELECT d FROM Disabled d WHERE d.braileBlock IS NOT NULL AND d.braileBlock <> '' AND d.guideHuman IS NOT NULL AND d.guideHuman <> ''")
-    List<Disabled> findByValidBraileBlockAndGuideHuman();
-
-    // 청각 장애 필터링 (수어 가이드, 비디오 가이드, 청각 장애 전용 객실 중 하나가 null이 아니고 빈 문자열이 아님)
-    @Query("SELECT d FROM Disabled d WHERE d.signGuide IS NOT NULL AND d.signGuide <> '' OR d.videoGuide IS NOT NULL AND d.videoGuide <> '' OR d.hearingRoom IS NOT NULL AND d.hearingRoom <> '' OR d.hearingHandicapEtc IS NOT NULL AND d.hearingHandicapEtc <> ''")
-    List<Disabled> findByValidSignGuideOrVideoGuideOrHearingRoomOrHearingHandicapEtc();
-
-    // 영유아 관련 필터링 (유모차, 수유실, 아기 의자가 중 하나가 null이 아니고 빈 문자열이 아님)
-    @Query("SELECT d FROM Disabled d WHERE d.stroller IS NOT NULL AND d.stroller <> '' OR d.lactationRoom IS NOT NULL AND d.lactationRoom <> '' OR d.babySpareChair IS NOT NULL AND d.babySpareChair <> '' OR d.infantsFamilyEtc IS NOT NULL AND d.infantsFamilyEtc <> ''")
-    List<Disabled> findByValidStrollerOrLactationRoomOrBabySpareChairOrInfantsFamilyEtc();
+//    // 노약자 필터링 (엘리베이터 또는 경로가 null이 아니고 빈 문자열이 아님)
+//    @Query("SELECT d FROM Disabled d WHERE d.elevator IS NOT NULL AND d.elevator <> '' OR d.route IS NOT NULL AND d.route <> ''")
+//    List<Disabled> findByValidElevatorOrRoute();
+//
+//    // 휠체어 필터링 (엘리베이터, 출입구, 대중교통이 null이 아니고 빈 문자열이 아님)
+//    @Query("SELECT d FROM Disabled d WHERE d.elevator IS NOT NULL AND d.elevator <> '' AND d.entrance IS NOT NULL AND d.entrance <> '' AND d.publicTransport IS NOT NULL AND d.publicTransport <> ''")
+//    List<Disabled> findByValidElevatorAndEntranceAndPublicTransport();
+//
+//    // 시각 장애 필터링 (점자 블록과 안내 요원이 null이 아니고 빈 문자열이 아님)
+//    @Query("SELECT d FROM Disabled d WHERE d.braileBlock IS NOT NULL AND d.braileBlock <> '' AND d.guideHuman IS NOT NULL AND d.guideHuman <> ''")
+//    List<Disabled> findByValidBraileBlockAndGuideHuman();
+//
+//    // 청각 장애 필터링 (수어 가이드, 비디오 가이드, 청각 장애 전용 객실 중 하나가 null이 아니고 빈 문자열이 아님)
+//    @Query("SELECT d FROM Disabled d WHERE d.signGuide IS NOT NULL AND d.signGuide <> '' OR d.videoGuide IS NOT NULL AND d.videoGuide <> '' OR d.hearingRoom IS NOT NULL AND d.hearingRoom <> '' OR d.hearingHandicapEtc IS NOT NULL AND d.hearingHandicapEtc <> ''")
+//    List<Disabled> findByValidSignGuideOrVideoGuideOrHearingRoomOrHearingHandicapEtc();
+//
+//    // 영유아 관련 필터링 (유모차, 수유실, 아기 의자가 중 하나가 null이 아니고 빈 문자열이 아님)
+//    @Query("SELECT d FROM Disabled d WHERE d.stroller IS NOT NULL AND d.stroller <> '' OR d.lactationRoom IS NOT NULL AND d.lactationRoom <> '' OR d.babySpareChair IS NOT NULL AND d.babySpareChair <> '' OR d.infantsFamilyEtc IS NOT NULL AND d.infantsFamilyEtc <> ''")
+//    List<Disabled> findByValidStrollerOrLactationRoomOrBabySpa{
+//    Disabled findDisabledByLocation(Location location);
+//
+//    // 노약자 필터링 (엘리베이터 또는 경로가 null이 아니고 빈 문자열이 아님)
+//    @Query("SELECT d FROM Disabled d WHERE d.elevator IS NOT NULL AND d.elevator <> '' OR d.route IS NOT NULL AND d.route <> ''")
+//    List<Disabled> findByValidElevatorOrRoute();
+//
+//    // 휠체어 필터링 (엘리베이터, 출입구, 대중교통이 null이 아니고 빈 문자열이 아님)
+//    @Query("SELECT d FROM Disabled d WHERE d.elevator IS NOT NULL AND d.elevator <> '' AND d.entrance IS NOT NULL AND d.entrance <> '' AND d.publicTransport IS NOT NULL AND d.publicTransport <> ''")
+//    List<Disabled> findByValidElevatorAndEntranceAndPublicTransport();
+//
+//    // 시각 장애 필터링 (점자 블록과 안내 요원이 null이 아니고 빈 문자열이 아님)
+//    @Query("SELECT d FROM Disabled d WHERE d.braileBlock IS NOT NULL AND d.braileBlock <> '' AND d.guideHuman IS NOT NULL AND d.guideHuman <> ''")
+//    List<Disabled> findByValidBraileBlockAndGuideHuman();
+//
+//    // 청각 장애 필터링 (수어 가이드, 비디오 가이드, 청각 장애 전용 객실 중 하나가 null이 아니고 빈 문자열이 아님)
+//    @Query("SELECT d FROM Disabled d WHERE d.signGuide IS NOT NULL AND d.signGuide <> '' OR d.videoGuide IS NOT NULL AND d.videoGuide <> '' OR d.hearingRoom IS NOT NULL AND d.hearingRoom <> '' OR d.hearingHandicapEtc IS NOT NULL AND d.hearingHandicapEtc <> ''")
+//    List<Disabled> findByValidSignGuideOrVideoGuideOrHearingRoomOrHearingHandicapEtc();
+//
+//    // 영유아 관련 필터링 (유모차, 수유실, 아기 의자가 중 하나가 null이 아니고 빈 문자열이 아님)
+//    @Query("SELECT d FROM Disabled d WHERE d.stroller IS NOT NULL AND d.stroller <> '' OR d.lactationRoom IS NOT NULL AND d.lactationRoom <> '' OR d.babySpareChair IS NOT NULL AND d.babySpareChair <> '' OR d.infantsFamilyEtc IS NOT NULL AND d.infantsFamilyEtc <> ''")
+//    List<Disabled> findByValidStrollerOrLactationRoomOrBabySpareChairOrInfantsFamilyEtc();
+//
+//
+//    @Query("SELECT d FROM Disabled d JOIN d.location l " +
+//            "WHERE (:senior = false OR (d.elevator IS NOT NULL AND d.route IS NOT NULL)) " +
+//            "AND (:wheelchair = false OR (d.elevator IS NOT NULL AND d.entrance IS NOT NULL AND d.publicTransport IS NOT NULL)) " +
+//            "AND (:blindHandicap = false OR (d.braileBlock IS NOT NULL AND d.guideHuman IS NOT NULL)) " +
+//            "AND (:hearingHandicap = false OR (d.signGuide IS NOT NULL OR d.videoGuide IS NOT NULL OR d.hearingRoom IS NOT NULL)) " +
+//            "AND (:infantsFamily = false OR (d.stroller IS NOT NULL OR d.lactationRoom IS NOT NULL OR d.babySpareChair IS NOT NULL)) " +
+//            "AND (" +
+//            "  :#{#travelTypes.isEmpty()} = true OR " + // 여행 타입이 없으면 무시
+//            "  (" +
+//            "    :#{#travelTypes} LIKE CONCAT('%', l.description, '%') " + // 리스트의 모든 항목을 동적으로 LIKE로 처리
+//            "  )" +
+//            ")")
+//    Set<Disabled> filterByDisabledAndTravelType(
+//            @Param("senior") boolean senior,
+//            @Param("wheelchair") boolean wheelchair,
+//            @Param("blindHandicap") boolean blindHandicap,
+//            @Param("hearingHandicap") boolean hearingHandicap,
+//            @Param("infantsFamily") boolean infantsFamily,
+//            @Param("travelTypes") List<String> travelTypes);
+//}
 }
+
+

--- a/BEF/src/main/java/com/example/BEF/Disabled/Service/DisabledService.java
+++ b/BEF/src/main/java/com/example/BEF/Disabled/Service/DisabledService.java
@@ -71,7 +71,7 @@ public class DisabledService {
         if (travelTypes != null && !travelTypes.isEmpty()) {
             queryBuilder.append("AND (");
             for (int i = 0; i < travelTypes.size(); i++) {
-                queryBuilder.append("l.description LIKE :travelType" + i);
+                queryBuilder.append("l.description LIKE :travelType").append(i);
                 if (i < travelTypes.size() - 1) {
                     queryBuilder.append(" OR ");
                 }

--- a/BEF/src/main/java/com/example/BEF/Disabled/Service/DisabledService.java
+++ b/BEF/src/main/java/com/example/BEF/Disabled/Service/DisabledService.java
@@ -3,53 +3,109 @@ package com.example.BEF.Disabled.Service;
 import com.example.BEF.Disabled.Domain.Disabled;
 import com.example.BEF.Location.Domain.Location;
 import com.example.BEF.User.DTO.UserDisabledDTO;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Query;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 @Service
+@Slf4j
 public class DisabledService {
 
     @Autowired
     DisabledRepository disabledRepository;
 
+    @PersistenceContext  // EntityManager 주입
+    private EntityManager entityManager;
+
     // 관광지 장애 정보 필터링
-    public Set<Disabled> filteringDisabled(UserDisabledDTO userDisabledDTO) {
-        Set<Disabled> filteredList = new HashSet<>();
+//    public Set<Disabled> filteringDisabled(UserDisabledDTO userDisabledDTO) {
+//        Set<Disabled> filteredList = new HashSet<>();
+//
+//        // 노약자 필터링
+//        // 필터링 : 엘리베이터 || 대중교통
+//        if (userDisabledDTO.getSenior())
+//            filteredList.addAll(disabledRepository.findByValidElevatorOrRoute());
+//
+//        // 휠체어 필터링
+//        // 필터링 : 엘리베이터 && 출입통로 && 경사로
+//        if (userDisabledDTO.getWheelchair())
+//            filteredList.addAll(disabledRepository.findByValidElevatorAndEntranceAndPublicTransport());
+//
+//        // 시각 장애 필터링
+//        // 필터링 : 점자블록 && 안내요원
+//        if (userDisabledDTO.getBlind_handicap())
+//            filteredList.addAll(disabledRepository.findByValidBraileBlockAndGuideHuman());
+//
+//        // 청각 장애 필터링
+//        // 필터링 : 수화 || 비디오 가이드 || 객실 || 청각 장애 기타 상세
+//        if (userDisabledDTO.getHearing_handicap())
+//            filteredList.addAll(disabledRepository.findByValidSignGuideOrVideoGuideOrHearingRoomOrHearingHandicapEtc());
+//
+//        // 영유아 필터링
+//        // 필터링 : 유모차 || 수유실 || 보조 의자 || 영유아 기타 상세
+//        if (userDisabledDTO.getInfants_family())
+//            filteredList.addAll(disabledRepository.findByValidStrollerOrLactationRoomOrBabySpareChairOrInfantsFamilyEtc());
+//
+//        return (filteredList);
+//    }
 
-        // 노약자 필터링
-        // 필터링 : 엘리베이터 || 대중교통
-        if (userDisabledDTO.getSenior())
-            filteredList.addAll(disabledRepository.findByValidElevatorOrRoute());
+    @Transactional
+    public Set<Disabled> filterByUserDisabilityAndTravelType(UserDisabledDTO userDisabledDTO, List<String> travelTypes) {
+        // 기본 SQL 쿼리
+        StringBuilder queryBuilder = new StringBuilder("SELECT d.* FROM disabled d JOIN location l ON d.content_id = l.content_id " +
+                "WHERE (:senior = false OR (d.elevator IS NOT NULL AND d.elevator <> '' AND d.entrance IS NOT NULL AND d.entrance <> '' AND d.public_transport IS NOT NULL AND d.public_transport <> '')) " +
+                "AND (:wheelchair = false OR (d.elevator IS NOT NULL AND d.elevator <> '' AND d.entrance IS NOT NULL AND d.entrance <> '' AND d.public_transport IS NOT NULL AND d.public_transport <> '')) " +
+                "AND (:blindHandicap = false OR (d.braile_block IS NOT NULL AND d.braile_block <> '' AND d.guide_human IS NOT NULL AND d.guide_human <> '')) " +
+                "AND (:hearingHandicap = false OR (d.sign_guide IS NOT NULL AND d.sign_guide <> '' OR d.video_guide IS NOT NULL AND d.video_guide <> '' OR d.hearing_room IS NOT NULL AND d.hearing_room <> '' OR d.hearing_handicap_etc IS NOT NULL AND d.hearing_handicap_etc <> '')) " +
+                "AND (:infantsFamily = false OR (d.stroller IS NOT NULL AND d.stroller <> '' OR d.lactation_room IS NOT NULL AND d.lactation_room <> '' OR d.baby_spare_chair IS NOT NULL AND d.baby_spare_chair <> '' OR d.infants_family_etc IS NOT NULL AND d.infants_family_etc <> '')) ");
 
-        // 휠체어 필터링
-        // 필터링 : 엘리베이터 && 출입통로 && 경사로
-        if (userDisabledDTO.getWheelchair())
-            filteredList.addAll(disabledRepository.findByValidElevatorAndEntranceAndPublicTransport());
+        // travelTypes가 존재하면 각 travelType에 대해 LIKE 조건 추가
+        if (travelTypes != null && !travelTypes.isEmpty()) {
+            queryBuilder.append("AND (");
+            for (int i = 0; i < travelTypes.size(); i++) {
+                queryBuilder.append("l.description LIKE :travelType" + i);
+                if (i < travelTypes.size() - 1) {
+                    queryBuilder.append(" OR ");
+                }
+            }
+            queryBuilder.append(")");
+        }
 
-        // 시각 장애 필터링
-        // 필터링 : 점자블록 && 안내요원
-        if (userDisabledDTO.getBlind_handicap())
-            filteredList.addAll(disabledRepository.findByValidBraileBlockAndGuideHuman());
+        // 로그로 SQL 쿼리 출력
+        log.info("Generated Query: {}", queryBuilder.toString());
 
-        // 청각 장애 필터링
-        // 필터링 : 수화 || 비디오 가이드 || 객실 || 청각 장애 기타 상세
-        if (userDisabledDTO.getHearing_handicap())
-            filteredList.addAll(disabledRepository.findByValidSignGuideOrVideoGuideOrHearingRoomOrHearingHandicapEtc());
+        // Query 생성
+        Query query = entityManager.createNativeQuery(queryBuilder.toString(), Disabled.class);
 
-        // 영유아 필터링
-        // 필터링 : 유모차 || 수유실 || 보조 의자 || 영유아 기타 상세
-        if (userDisabledDTO.getInfants_family())
-            filteredList.addAll(disabledRepository.findByValidStrollerOrLactationRoomOrBabySpareChairOrInfantsFamilyEtc());
+        // 파라미터 바인딩
+        query.setParameter("senior", userDisabledDTO.getSenior());
+        query.setParameter("wheelchair", userDisabledDTO.getWheelchair());
+        query.setParameter("blindHandicap", userDisabledDTO.getBlind_handicap());
+        query.setParameter("hearingHandicap", userDisabledDTO.getHearing_handicap());
+        query.setParameter("infantsFamily", userDisabledDTO.getInfants_family());
 
-        return (filteredList);
+        // travelTypes가 존재하면 각 travelType에 대한 파라미터 설정
+        if (travelTypes != null && !travelTypes.isEmpty()) {
+            for (int i = 0; i < travelTypes.size(); i++) {
+                query.setParameter("travelType" + i, "%" + travelTypes.get(i) + "%");
+            }
+        }
+
+        // 결과 실행 및 반환
+        List<Disabled> resultList = query.getResultList();
+        return new HashSet<>(resultList);  // 중복 제거를 위해 Set으로 변환
     }
 
 
     public Disabled findDisabledByLocation(Location location) {
         return disabledRepository.findDisabledByLocation(location);
     }
-
 }

--- a/BEF/src/main/java/com/example/BEF/Location/Controller/LocationController.java
+++ b/BEF/src/main/java/com/example/BEF/Location/Controller/LocationController.java
@@ -1,7 +1,6 @@
 package com.example.BEF.Location.Controller;
 
 import com.example.BEF.Location.DTO.LocationInfoRes;
-import com.example.BEF.Location.DTO.UserLocationRes;
 import com.example.BEF.Location.Service.LocationService;
 import com.example.BEF.User.Service.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,13 +24,13 @@ public class LocationController {
 
     // 유저 장애 정보 기반 관광지 리스트 검색
     @GetMapping("/recommend")
-    public ResponseEntity<List<UserLocationRes>> getUserLocations(@RequestParam("userNumber") Long userNumber) {
+    public ResponseEntity<List<LocationInfoRes>> getRecLocations(@RequestParam("travelType") List<String> travelType, @RequestParam("userNumber") Long userNumber) {
         // 존재하지 않는 유저인 경우
         if (userRepository.findUserByUserNumber(userNumber) == null)
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
 
         // 필터링된 관광지 리스트 리턴
-        return new ResponseEntity<>(locationService.findLocationWithDisabled(userNumber), HttpStatus.OK);
+        return new ResponseEntity<>(locationService.filteringLocations(travelType, userNumber), HttpStatus.OK);
     }
 
     // 지역(구) 기반 관광지 리스트 검색

--- a/BEF/src/main/java/com/example/BEF/Location/Controller/LocationController.java
+++ b/BEF/src/main/java/com/example/BEF/Location/Controller/LocationController.java
@@ -24,13 +24,13 @@ public class LocationController {
 
     // 유저 장애 정보 기반 관광지 리스트 검색
     @GetMapping("/recommend")
-    public ResponseEntity<List<LocationInfoRes>> getRecLocations(@RequestParam("travelType") List<String> travelType, @RequestParam("userNumber") Long userNumber) {
+    public ResponseEntity<List<LocationInfoRes>> getRecLocations(@RequestParam("userNumber") Long userNumber) {
         // 존재하지 않는 유저인 경우
         if (userRepository.findUserByUserNumber(userNumber) == null)
             return new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
 
         // 필터링된 관광지 리스트 리턴
-        return new ResponseEntity<>(locationService.filteringLocations(travelType, userNumber), HttpStatus.OK);
+        return new ResponseEntity<>(locationService.filteringLocations(userNumber), HttpStatus.OK);
     }
 
     // 지역(구) 기반 관광지 리스트 검색

--- a/BEF/src/main/java/com/example/BEF/Location/DTO/LocationInfoRes.java
+++ b/BEF/src/main/java/com/example/BEF/Location/DTO/LocationInfoRes.java
@@ -7,6 +7,7 @@ import lombok.Data;
 @Data
 public class LocationInfoRes {
     //location 관련
+    private Long   contentId;
     private String contentTitle;
     private String addr;
     private Double gpsX;
@@ -38,6 +39,7 @@ public class LocationInfoRes {
     private String babySpareChair;
 
     public LocationInfoRes(Location location, Disabled disabled) {
+        this.contentId = location.getContentId();
         this.contentTitle = location.getContentTitle();
         this.addr = location.getAddr();
         this.gpsX = location.getGpsX();

--- a/BEF/src/main/java/com/example/BEF/Location/Service/LocationService.java
+++ b/BEF/src/main/java/com/example/BEF/Location/Service/LocationService.java
@@ -4,7 +4,6 @@ import com.example.BEF.Disabled.Domain.Disabled;
 import com.example.BEF.Disabled.Service.DisabledRepository;
 import com.example.BEF.Disabled.Service.DisabledService;
 import com.example.BEF.Location.DTO.LocationInfoRes;
-import com.example.BEF.Location.DTO.UserLocationRes;
 import com.example.BEF.Location.Domain.Location;
 import com.example.BEF.User.DTO.UserDisabledDTO;
 import com.example.BEF.User.Service.UserService;
@@ -13,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -32,23 +32,41 @@ public class LocationService {
     LocationRepository locationRepository;
 
     // 관광지 필터링 - 유저 장애 정보 관련
-    public List<UserLocationRes> findLocationWithDisabled(Long userNumber) {
+    public List<LocationInfoRes> filteringLocations(List<String> travelType, Long userNumber) {
+        // 필터링된 관광지 리스트
+        List<LocationInfoRes> locationInfoResList = new ArrayList<>();
+
+        // 여행 타입별 단어 리스트
+        List<String> userType = new ArrayList<>();
+
+        if (travelType.contains("forest"))
+            userType.addAll(Arrays.asList("숲", "휴양림", "산림욕장", "치유"));
+        if (travelType.contains("ocean"))
+            userType.addAll(Arrays.asList("해수욕장", "바다", "물놀이", "호수"));
+        if (travelType.contains("history"))
+            userType.addAll(Arrays.asList("박물관", "미술관", "역사", "문화", "사찰"));
+        if (travelType.contains("outside"))
+            userType.addAll(Arrays.asList("가족", "어린이", "공원", "파크", "레저"));
+
         // 유저 장애 정보
         UserDisabledDTO userDisabledDTO = userService.settingUserDisabled(userNumber);
 
         // 필터링 된 관광지 장애 정보 리스트
-        Set<Disabled> disabledList = disabledService.filteringDisabled(userDisabledDTO);
-        List<UserLocationRes> userLocationResList = new ArrayList<>();
+        Set<Disabled> filteredDisabledList = disabledService.filterByUserDisabilityAndTravelType(userDisabledDTO, userType);
 
-        // 필터링 된 관광지 정보 리스트 리턴
-        for (Disabled disabled : disabledList) {
+        // 필터링 된 관광지 정보 리스트 리턴 - MAX 20
+        Long idx = 0L;
+        for (Disabled disabled : filteredDisabledList) {
+            if (idx == 20L)
+                break;
             Location location = disabled.getLocation();
-            UserLocationRes userLocationRes = new UserLocationRes(location.getContentTitle(), location.getAddr(), location.getThumbnailImage());
-            userLocationResList.add(userLocationRes);
+            LocationInfoRes userLocationRes = new LocationInfoRes(location, disabled);
+            locationInfoResList.add(userLocationRes);
+            idx++;
         }
 
-        log.info("관광지 리스트 개수 : {}", userLocationResList.size());
-        return (userLocationResList);
+        log.info("관광지 리스트 개수 : {}", locationInfoResList.size());
+        return (locationInfoResList);
     }
 
     // 관광지 필터링 - 지역 관련

--- a/BEF/src/main/java/com/example/BEF/Location/Service/LocationService.java
+++ b/BEF/src/main/java/com/example/BEF/Location/Service/LocationService.java
@@ -6,6 +6,8 @@ import com.example.BEF.Disabled.Service.DisabledService;
 import com.example.BEF.Location.DTO.LocationInfoRes;
 import com.example.BEF.Location.Domain.Location;
 import com.example.BEF.User.DTO.UserDisabledDTO;
+import com.example.BEF.User.Domain.User;
+import com.example.BEF.User.Service.UserRepository;
 import com.example.BEF.User.Service.UserService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,21 +33,25 @@ public class LocationService {
     @Autowired
     LocationRepository locationRepository;
 
+    @Autowired
+    UserRepository userRepository;
+
     // 관광지 필터링 - 유저 장애 정보 관련
-    public List<LocationInfoRes> filteringLocations(List<String> travelType, Long userNumber) {
+    public List<LocationInfoRes> filteringLocations(Long userNumber) {
         // 필터링된 관광지 리스트
         List<LocationInfoRes> locationInfoResList = new ArrayList<>();
 
         // 여행 타입별 단어 리스트
+        User user = userRepository.findUserByUserNumber(userNumber);
         List<String> userType = new ArrayList<>();
 
-        if (travelType.contains("forest"))
+        if (user.getForest())
             userType.addAll(Arrays.asList("숲", "휴양림", "산림욕장", "치유"));
-        if (travelType.contains("ocean"))
+        if (user.getOcean())
             userType.addAll(Arrays.asList("해수욕장", "바다", "물놀이", "호수"));
-        if (travelType.contains("history"))
+        if (user.getCulture())
             userType.addAll(Arrays.asList("박물관", "미술관", "역사", "문화", "사찰"));
-        if (travelType.contains("outside"))
+        if (user.getOutside())
             userType.addAll(Arrays.asList("가족", "어린이", "공원", "파크", "레저"));
 
         // 유저 장애 정보
@@ -65,7 +71,6 @@ public class LocationService {
             idx++;
         }
 
-        log.info("관광지 리스트 개수 : {}", locationInfoResList.size());
         return (locationInfoResList);
     }
 
@@ -83,7 +88,6 @@ public class LocationService {
             locationInfoResList.add(locationInfoRes);
         }
 
-        log.info("관광지 리스트 개수 : {}", locationInfoResList.size());
         return (locationInfoResList);
     }
 }

--- a/BEF/src/main/java/com/example/BEF/User/DTO/UserJoinReq.java
+++ b/BEF/src/main/java/com/example/BEF/User/DTO/UserJoinReq.java
@@ -2,6 +2,8 @@ package com.example.BEF.User.DTO;
 
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class UserJoinReq {
     private String userName;
@@ -12,6 +14,7 @@ public class UserJoinReq {
     private Boolean blindHandicap;
     private Boolean hearingHandicap;
     private Boolean infantsFamily;
+    private List<String> travelType;
 
     public boolean validJoin() {
         if (userName == null || userName.isBlank())
@@ -28,8 +31,6 @@ public class UserJoinReq {
             return false;
         else if (hearingHandicap == null)
             return false;
-        else if (infantsFamily == null)
-            return false;
-        return true;
+        else return infantsFamily != null;
     }
 }

--- a/BEF/src/main/java/com/example/BEF/User/Domain/User.java
+++ b/BEF/src/main/java/com/example/BEF/User/Domain/User.java
@@ -39,6 +39,18 @@ public class User {
     @Column(name = "infants_family")
     private Boolean infantsFamily; // 영유아 가족
 
+    @Column(name = "forest")
+    private Boolean forest;
+
+    @Column(name = "ocean")
+    private Boolean ocean;
+
+    @Column(name = "culture")
+    private Boolean culture;
+
+    @Column(name = "outside")
+    private Boolean outside;
+
     public User(String userName, String gender, Long age, Boolean senior, Boolean wheelchair, Boolean blindHandicap, Boolean hearingHandicap, Boolean infantsFamily) {
         this.userName = userName;
         this.gender = gender;

--- a/BEF/src/main/java/com/example/BEF/User/Service/UserService.java
+++ b/BEF/src/main/java/com/example/BEF/User/Service/UserService.java
@@ -30,6 +30,12 @@ public class UserService {
         savedUser.setHearingHandicap(userJoinReq.getHearingHandicap());
         savedUser.setInfantsFamily(userJoinReq.getInfantsFamily());
 
+        // 유저 여행 타입 설정
+        savedUser.setForest(userJoinReq.getTravelType().contains("forest"));
+        savedUser.setOcean(userJoinReq.getTravelType().contains("ocean"));
+        savedUser.setCulture(userJoinReq.getTravelType().contains("culture"));
+        savedUser.setOutside(userJoinReq.getTravelType().contains("outside"));
+
         // 유저 저장
         userRepository.save(savedUser);
 


### PR DESCRIPTION
## 온보딩 API
### Request로 List<String> travelType(여행 타입) 받기
여행 타입으로 forest, ocean, culture, outside가 들어올 수 있다.
리스트에 각각의 존재 여부에 따라 유저 정보에 true로 설정.

## 유저별 여행 타입 + 장애 정보 필터링 API
### LocationService
**유저 선호 여행 타입에 맞춰 관광지 필터링 단어 추가**
-> forest : "숲", "휴양림", "산림욕장", "치유"
-> ocean : "해수욕장", "바다", "물놀이", "호수"
-> culture : "박물관", "미술관", "역사", "문화", "사찰"
-> outside : "가족", "어린이", "공원", "파크", "레저"
</br>

### DisabledService
**쿼리문으로 유저 장애 정보, 여행 타입에 맞춰 필터링**

관광지 개수 20개로 잘라 리스트 리턴
