### PR TITLE
[Fix] AI 여행 코스 생성 API

### DIFF
--- a/BEF/src/main/java/com/example/BEF/Course/Controller/CourseController.java
+++ b/BEF/src/main/java/com/example/BEF/Course/Controller/CourseController.java
@@ -68,16 +68,15 @@ public class CourseController {
     }
 
     // 코스 추가 API
-    @PostMapping("/{userNumber}/create")
+    @PostMapping("/create")
     @Operation(summary = "코스 리스트 생성", description = "코스 리스트 생성 API")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "코스 생성에 성공하였습니다.", content = @Content(mediaType = "application/json")),
             @ApiResponse(responseCode = "400", description = "존재하지 않는 유저입니다.", content = @Content(mediaType = "application/json")),
     })
-    @Parameter(name = "userNumber", description = "유저 번호", example = "32")
-    public ResponseEntity<CourseInfoRes> addCourse(@PathVariable("userNumber") Long userNumber, @RequestBody CreateCourseReq createCourseReq) {
+    public ResponseEntity<CourseInfoRes> addCourse(@RequestBody CreateCourseReq createCourseReq) {
         // 유저 조회
-        User user = userRepository.findUserByUserNumber(userNumber);
+        User user = userRepository.findUserByUserNumber(createCourseReq.getUserNumber());
 
         // 존재하지 않는 유저일 때
         if (user == null)

--- a/BEF/src/main/java/com/example/BEF/Course/Domain/CourseTripType.java
+++ b/BEF/src/main/java/com/example/BEF/Course/Domain/CourseTripType.java
@@ -1,0 +1,29 @@
+package com.example.BEF.Course.Domain;
+
+import com.example.BEF.TripType.TripType;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+public class CourseTripType {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "course_number")
+    private Course course;
+
+    @ManyToOne
+    @JoinColumn(name = "trip_type_number")
+    private TripType tripType;
+
+    @Builder
+    public CourseTripType(Course course, TripType tripType) {
+        this.course = course;
+        this.tripType = tripType;
+    }
+}
+

--- a/BEF/src/main/java/com/example/BEF/Course/Domain/UserCourse.java
+++ b/BEF/src/main/java/com/example/BEF/Course/Domain/UserCourse.java
@@ -22,7 +22,7 @@ public class UserCourse {
     @Column(name = "day")
     private Long day;
 
-    @Column(name = "order")
+    @Column(name = "`order`")
     private Long order;
 
     @ManyToOne

--- a/BEF/src/main/java/com/example/BEF/Course/Repository/CourseTripTypeRepository.java
+++ b/BEF/src/main/java/com/example/BEF/Course/Repository/CourseTripTypeRepository.java
@@ -1,0 +1,9 @@
+package com.example.BEF.Course.Repository;
+
+import com.example.BEF.Course.Domain.CourseTripType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CourseTripTypeRepository extends JpaRepository<CourseTripType, Long> {
+}

--- a/BEF/src/main/java/com/example/BEF/Course/Service/AIRecCourse.java
+++ b/BEF/src/main/java/com/example/BEF/Course/Service/AIRecCourse.java
@@ -162,7 +162,7 @@ public class AIRecCourse {
         saveCourseDisabilities(disability, course);
         saveCourseTripTypes(tripType, course);
 
-        return CourseLocRes.of(course.getCourseNumber(), course.getCourseName(), createSimpleLocsByCourse(userCoursesByAICourse));
+        return CourseLocRes.of(course.getCourseNumber(), "", createSimpleLocsByCourse(userCoursesByAICourse));
     }
 
     private List<List<SimpleLoc>> createSimpleLocsByCourse(List<UserCourse> userCourses) {

--- a/BEF/src/main/java/com/example/BEF/Course/Service/CourseService.java
+++ b/BEF/src/main/java/com/example/BEF/Course/Service/CourseService.java
@@ -135,7 +135,7 @@ public class CourseService {
 //                .limit(80)
 //                .toList();
 
-        return aiRecCourse.generateCourse(filteredLocation, disability, area, period);
+        return aiRecCourse.generateCourse(filteredLocation, disability, tripType, area, period);
     }
 
     @Transactional


### PR DESCRIPTION
## AI 여행 코스 생성 API 수정

### 기존 로직 수정
기존 로직 오류를 두 개 수정했습니다.
- courseName을 입력받지 않는데 접근자를 사용해 이 부분을 수정했습니다.
- UserCourse의 order가 예약어라 오류가 발생해 이 부분을 수정했습니다.
- courseName, userNumber 값이 NULL로 저장될 수 있게 DB 스키마를 수정했습니다.

### 코스별 여행 타입
기존 로직은 코스별 장애 유형만 저장해 여행 타입도 받아주기 위해 관련 내용을 구현했습니다.
- CourseTripType 도메인, 리포지토리를 생성했습니다.
- AI 코스 생성 시 코스별 여행 타입을 생성하는 로직을 구현했습니다.
